### PR TITLE
Fixed spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Timesheet.js
 
-Simple JavaScript library to create HTML time sheets. Wrapped in an example project using Middleman …
+Simple JavaScript library to create HTML time sheets. Wrapped in an example project using Middleman…
 
 ![https://semu.github.io/timesheet.js](https://raw.githubusercontent.com/semu/timesheet.js/master/screen.png)
 


### PR DESCRIPTION
I fixed an issue in spacing in the README. There was an unnecessary space between "Middleman" and the ellipses. Please see screenshot for the issue:

![image](https://cloud.githubusercontent.com/assets/7344640/4330593/36ae86d0-3fb2-11e4-8aa3-f92daef278c8.png)
